### PR TITLE
docs: Mathcing data params in server-side example for custom events' plugin config

### DIFF
--- a/docs/examples/events.md
+++ b/docs/examples/events.md
@@ -49,7 +49,7 @@ module.exports = ({ env }) => ({
 			events: [
 				{
 					name: 'update-user-name',
-					handler: ({ strapi }, socket, name) => {
+					handler: ({ strapi }, socket, id, name) => {
 						strapi.log.info(`[io] trigger update for socket ${socket.id}.`);
 
 						// update the respective users name.


### PR DESCRIPTION
The server-side code should include `id` as receivable data along with `name` - this then matches the data entities sent by the client and `id` was also used in the server code without prior definition. Let me know if I'm wrong, I didn't test it locally.

<!--- PR title should follow conventional commits (https://conventionalcommits.org) -->

### Description
Added `id` param to [custom events example config](https://strapi-plugin-io.netlify.app/examples/events.html#plugin-configuration-1) to match the [event proto](https://strapi-plugin-io.netlify.app/examples/events.html#client-socket) of client
<!-- Describe your changes in detail -->
<!-- What changes have been made -->

### Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Documentation (updates to the documentation or readme)
- [ ] Bug fix (a non-breaking change that fixes an issue)
- [ ] Enhancement (improving an existing functionality like performance)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Relevant Issue(s)

<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
